### PR TITLE
1.1.2.1

### DIFF
--- a/GameData/OhScrap/Changelog.cfg
+++ b/GameData/OhScrap/Changelog.cfg
@@ -2,9 +2,12 @@ KERBALCHANGELOG //Required to have this name
 {
   showChangelog = True //To show the changelog, this must be set to True
   modName = OhScrap //Add your mod's name here
+  license = MIT
+  author = Magico13, SeveredSolo and zer0Kerbal
 VERSION
 {
   version = 2.1.0.0
+  versionname = >>-- Adoption by zer0Kerbal -->>
   change = recompile for KSP 1.9.1
   change = recompile with .NET 4.8
   change = folder restructure
@@ -13,6 +16,13 @@ VERSION
   change = adjust autobuild/deploy process to zer0Kerbal
   change = Logger.cs - use Version.Number from tt processes
   change = log path from /severedsolo/OhScrap/Logs/ to /OhScrap/Logs/
+  change = added AVC-VersionFileValidator.yml (thank you to @DasSkelett and @HebaruSan)
+  CHANGE
+  {
+    change = Patches
+    change = added FailureRepairSkill.cfg for MKS/Mechanics and Squad/Engineers
+    change = added :NEEDS and :FOR to all patches
+  }
 }
 VERSION
 {

--- a/GameData/OhScrap/Patches/FailureRepairSkill.cfg
+++ b/GameData/OhScrap/Patches/FailureRepairSkill.cfg
@@ -1,0 +1,25 @@
+// FailureRepairSkill.cfg v1.0.0.0
+// OhScrap!
+// created: 2020 03 08 
+// updated: 2020 03 08
+
+@EXPERIENCE_TRAIT[Mechanic]:NEEDS[OhScrap,ScrapYard,UmbraSpaceIndustries/MKS]:FOR[OhScrap]
+{
+	EFFECT
+	{
+		name = FailureRepairSkill
+		modifiers = 1.01, 1.03, 1.06, 1.10, 1.15
+	}
+}
+
+@EXPERIENCE_TRAIT[Engineer]:NEEDS[OhScrap,ScrapYard]:FOR[OhScrap]
+{
+	EFFECT
+	{
+		name = FailureRepairSkill
+		modifiers = 1.01, 1.03, 1.06, 1.10, 1.15
+	}
+}
+
+// CC BY-NC-SA-4.0
+// zer0Kerbal

--- a/OhScrap/ModuleUPFMEvents.cs
+++ b/OhScrap/ModuleUPFMEvents.cs
@@ -191,11 +191,24 @@ namespace OhScrap
                 {
                     //Engineers give a 10% bonus per level to repair rates
                     ProtoCrewMember p = FlightGlobals.ActiveVessel.GetVesselCrew().ElementAt(i);
-                    if(p.trait == "Engineer")
+                    for(int ii = 0; ii < p.experienceTrait.Effects.Count(); ii++)
+                        if  (p.experienceTrait.Effects[ii].Name == "FailureRepairSkill")
+                        {
+                            if (p.experienceTrait.Effects[ii].LevelModifiers.Length > 0)
+                            { 
+                                repairChance += p.experienceTrait.Effects[ii].LevelModifiers[p.experienceLevel];
+                                Debug.Log(String.Format("[OhScrap]: name {0) experiencetrait {1) level {2) modifier {3)", p.name, p.experienceTrait.ToString(), p.experienceLevel.ToString(), p.experienceTrait.Effects[ii].LevelModifiers[p.experienceLevel].ToString()));
+                            }
+                            else repairChance += p.experienceLevel * 0.1f;
+                            break;
+                    }
+                            //p.experienceTrait.Effects[ii].Level
+                   /* if (p.experienceTrait.Effects == "FailureRepairSkill")
+                    // if ((p.trait == "Engineer") || (p.trait == "Mechanic"))
                     {
                         repairChance += p.experienceLevel*0.1f;
                         break;
-                    }
+                    }*/
                 }
             }
             double roll = UPFMUtils.instance._randomiser.NextDouble();


### PR DESCRIPTION
- Allow 'Mechanics' from USI to affect effets
  - suggested by @dirk
  - current code allowed Engineers (and only Engineers) a bonus to repairs
  - adjusted code to allow any Kerbal with the "FailureRepairSkill" to receive a bonus to repairs
  - FailureRepairSkill is a Stock skill that all Engineers have
  - added a patch that adds FailureRepairSkill to USI MKS Mechanics
  - easy to add "FailureRepairSkill" to other careers if requested by users