### PR TITLE
Fix remote version file URL after branch rename

### DIFF
--- a/OhScrap.version
+++ b/OhScrap.version
@@ -1,12 +1,12 @@
 {
     "NAME"          : "Oh Scrap!",
-    "URL"           : "https://raw.githubusercontent.com/zer0Kerbal/OhScrap/master/OhScrap.version",
+    "URL"           : "https://raw.githubusercontent.com/zer0Kerbal/OhScrap/base/OhScrap.version",
     "DOWNLOAD"      : "https://github.com/zer0Kerbal/OhScrap/releases/latest/",
     "CHANGE_LOG_URL": "https://raw,githubusercontent.com/zer0Kerbal/OhScrap/master/Changelog.cfg",
     "GITHUB" :
     {
         "USERNAME"         : "zer0Kerbal",
-        "REPOSITORY"       :"OhScrap",
+        "REPOSITORY"       : "OhScrap",
         "ALLOW_PRE_RELEASE": false
     },
     "VERSION" :


### PR DESCRIPTION
Hey @zer0Kerbal, we've got the following warning from our bot earlier today:

> New inflation warnings for OhScrap: Error fetching remote version file https://raw.githubusercontent.com/zer0Kerbal/OhScrap/master/OhScrap.version: The remote server returned an error: (404) Not Found.

Looks like the branch has been renamed from `master` to `base`.

This PR updates the `URL` property to point to the new branch, so that the next release will have a working remote version file again.