### PR TITLE
Fix version file URLs

### DIFF
--- a/OhScrap.version
+++ b/OhScrap.version
@@ -1,5 +1,5 @@
 {
-    "NAME"          : "Oh Scrap!",
+    "NAME"          : "Oh Scrap! (OHS)",
     "URL"           : "https://raw.githubusercontent.com/zer0Kerbal/OhScrap/master/OhScrap.version",
     "DOWNLOAD"      : "https://github.com/zer0Kerbal/OhScrap/releases/latest/",
     "CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/OhScrap/master/Changelog.cfg",

--- a/OhScrap.version
+++ b/OhScrap.version
@@ -1,8 +1,8 @@
 {
     "NAME"          : "Oh Scrap!",
-    "URL"           : "https://raw.githubusercontent.com/zer0Kerbal/OhScrap/base/OhScrap.version",
+    "URL"           : "https://raw.githubusercontent.com/zer0Kerbal/OhScrap/master/OhScrap.version",
     "DOWNLOAD"      : "https://github.com/zer0Kerbal/OhScrap/releases/latest/",
-    "CHANGE_LOG_URL": "https://raw,githubusercontent.com/zer0Kerbal/OhScrap/base/Changelog.cfg",
+    "CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/OhScrap/master/Changelog.cfg",
     "GITHUB" :
     {
         "USERNAME"         : "zer0Kerbal",


### PR DESCRIPTION
Hi @zer0Kerbal,

- Both URLs have `base` where they should have the branch name the repo uses, `master`
- One of them has a comma instead of a period

Should be fixed with these changes.

Noticed while reviewing KSP-CKAN/NetKAN#8784.